### PR TITLE
Add 24r as possible vmSize

### DIFF
--- a/Scripts/CreateDSVM/Ubuntu/azuredeploy.json
+++ b/Scripts/CreateDSVM/Ubuntu/azuredeploy.json
@@ -37,6 +37,7 @@
                 "Standard_NC6",
                 "Standard_NC12",
                 "Standard_NC24",
+                "Standard_NC24r",
                 
             ],
             "metadata": {

--- a/Scripts/CreateDSVM/Ubuntu/azuredeploysshkey.json
+++ b/Scripts/CreateDSVM/Ubuntu/azuredeploysshkey.json
@@ -37,6 +37,7 @@
                 "Standard_NC6",
                 "Standard_NC12",
                 "Standard_NC24",
+                "Standard_NC24r",
                 
             ],
             "metadata": {

--- a/Scripts/CreateDSVM/Ubuntu/multiazuredeploy.json
+++ b/Scripts/CreateDSVM/Ubuntu/multiazuredeploy.json
@@ -44,6 +44,7 @@
                 "Standard_NC6",
                 "Standard_NC12",
                 "Standard_NC24",
+                "Standard_NC24r",
 
             ],
             "metadata": {

--- a/Scripts/CreateDSVM/Ubuntu/multiazuredeploywithext.json
+++ b/Scripts/CreateDSVM/Ubuntu/multiazuredeploywithext.json
@@ -44,6 +44,7 @@
                 "Standard_NC6",
                 "Standard_NC12",
                 "Standard_NC24",
+                "Standard_NC24r",
 
             ],
             "metadata": {

--- a/Scripts/CreateDSVM/Windows2012/azuredeploy.json
+++ b/Scripts/CreateDSVM/Windows2012/azuredeploy.json
@@ -28,11 +28,16 @@
                 "Standard_A2_v2",
                 "Standard_A4_v2",
                 "Standard_A8_v2",
+                "Standard_DS2_v2",
                 "Standard_DS3_v2",
                 "Standard_DS4_v2",
                 "Standard_DS12_v2",
                 "Standard_DS13_v2",
-                "Standard_DS14_v2"
+                "Standard_DS14_v2",
+                "Standard_NC6",
+                "Standard_NC12",
+                "Standard_NC24"
+                "Standard_NC24r",
             ],
             "metadata": {
                 "description": "Size for the Virtual Machine."

--- a/Scripts/CreateDSVM/Windows2012/multiazuredeploywithext.json
+++ b/Scripts/CreateDSVM/Windows2012/multiazuredeploywithext.json
@@ -44,6 +44,7 @@
                 "Standard_NC6",
                 "Standard_NC12",
                 "Standard_NC24"
+                "Standard_NC24r",
             ],
             "metadata": {
                 "description": "Size for the Virtual Machine."


### PR DESCRIPTION
Are 24r VM sizes supported in both Windows and Ubuntu DSVMs? I am sure they are in Ubuntu since I just deployed one, but haven't checked Windows yet.