### PR TITLE
added ability to use v3 VM for windows 2016 DSVM

### DIFF
--- a/Scripts/CreateDSVM/Windows2016/azuredeploy.json
+++ b/Scripts/CreateDSVM/Windows2016/azuredeploy.json
@@ -32,7 +32,8 @@
                 "Standard_DS4_v2",
                 "Standard_DS12_v2",
                 "Standard_DS13_v2",
-                "Standard_DS14_v2"
+                "Standard_DS14_v2",
+                "Standard_D4s_v3"
             ],
             "metadata": {
                 "description": "Size for the Virtual Machine."


### PR DESCRIPTION
just added D4s_v3 as a possible vmSize to the Windows 2016 deploy script. Successfully tested.