### PR TITLE
Add install of nb_conda_kernels

### DIFF
--- a/Extensions/fastaiv1/fastaiLinux.sh
+++ b/Extensions/fastaiv1/fastaiLinux.sh
@@ -5,6 +5,7 @@ pip install dataclasses
 /anaconda/bin/conda install  -y -c pytorch pytorch torchvision cudatoolkit=9.0
 /anaconda/bin/conda install  -y -c fastai fastai
 /anaconda/bin/conda install  -y ipykernel
+/anaconda/bin/conda install  -y nb_conda_kernels
 python -m ipykernel install --name 'fastai' --display-name 'Python (fastai)'
 # Script to update Notbook metadata
 cat << EOF > /tmp/changenbmeta.py


### PR DESCRIPTION
Without this the doc calls will fail - as in the lesson1-pets.ipynb.  This uses the kernel extensions to show inline documentation.