### PR TITLE
Added ipywidgets installation to fastai env

### DIFF
--- a/Extensions/fastaiv1/fastaiLinux.sh
+++ b/Extensions/fastaiv1/fastaiLinux.sh
@@ -4,7 +4,7 @@ source /anaconda/bin/activate fastai
 pip install dataclasses
 /anaconda/bin/conda install  -y -c pytorch pytorch torchvision cudatoolkit=9.0
 /anaconda/bin/conda install  -y -c fastai fastai
-/anaconda/bin/conda install  -y ipykernel nbconvert
+/anaconda/bin/conda install  -y ipykernel nbconvert ipywidgets
 python -m ipykernel install --name 'fastai' --display-name 'Python (fastai)'
 # Script to update Notbook metadata
 cat << EOF > /tmp/changenbmeta.py

--- a/Extensions/fastaiv1/fastaiWindows.ps1
+++ b/Extensions/fastaiv1/fastaiWindows.ps1
@@ -1,4 +1,4 @@
-cmd.exe /c "activate root &  conda create -y -n fastai python=3.6.5 ipykernel nbconvert scipy"
+cmd.exe /c "activate root &  conda create -y -n fastai python=3.6.5 ipykernel nbconvert scipy ipywidgets"
 cmd.exe /c "activate fastai &  conda install -c pytorch pytorch=1.0.0  -y"
 cmd.exe /c "activate fastai &  pip install fastai"
 function fixKernelSpec()  ##Fix the kernels name in course notebook to ensure right kernel is started


### PR DESCRIPTION
I was unable to run the following line from the fastai lesson 2 notebook
    
    from fastai.widgets import *

I got "No module named ‘ipywidgets’" 

I was able to solve this by running the following 

    source /anaconda/bin/activate fastai
    conda install ipywidgets

I think we should just go ahead an install ipywidgets when initially setting up the fastai environment 